### PR TITLE
Update MiraiEventHandler.py

### DIFF
--- a/SAGIRIBOT/Handler/Handlers/MiraiEventHandler.py
+++ b/SAGIRIBOT/Handler/Handlers/MiraiEventHandler.py
@@ -190,8 +190,7 @@ async def group_allow_member_invite_changed(app: GraiaMiraiApplication, event: G
 async def member_card_changed(app: GraiaMiraiApplication, event: MemberCardChangeEvent):
     try:
         if event.operator:
-            # mirai 的奇奇怪怪问题，新进群聊的成员第一条发言会触发 MemberCardChangeEvent，但是 member.name == origin 且 current = ""
-            if event.member.name == event.origin:
+            if event.member.name == event.origin or event.origin == "" or event.current == "":
                 pass
             else:
                 await app.sendGroupMessage(
@@ -200,7 +199,7 @@ async def member_card_changed(app: GraiaMiraiApplication, event: MemberCardChang
                     ])
                 )
         else:
-            if event.member.name == event.origin:
+            if event.member.name == event.origin or event.origin == "" or event.current == "":
                 pass
             else:
                 await app.sendGroupMessage(

--- a/SAGIRIBOT/Handler/Handlers/MiraiEventHandler.py
+++ b/SAGIRIBOT/Handler/Handlers/MiraiEventHandler.py
@@ -190,17 +190,24 @@ async def group_allow_member_invite_changed(app: GraiaMiraiApplication, event: G
 async def member_card_changed(app: GraiaMiraiApplication, event: MemberCardChangeEvent):
     try:
         if event.operator:
-            await app.sendGroupMessage(
-                group, MessageChain.create([
-                    Plain(text=f"啊嘞嘞？{event.member.name}的群名片被{event.operator.name}从{event.origin}改为{event.current}了呢！")
-                ])
-            )
+            # mirai 的奇奇怪怪问题，新进群聊的成员第一条发言会触发 MemberCardChangeEvent，但是 member.name == origin 且 current = ""
+            if event.member.name == event.origin:
+                pass
+            else:
+                await app.sendGroupMessage(
+                    group, MessageChain.create([
+                        Plain(text=f"啊嘞嘞？{event.member.name}的群名片被{event.operator.name}从{event.origin}改为{event.current}了呢！")
+                    ])
+                )
         else:
-            await app.sendGroupMessage(
-                group, MessageChain.create([
-                    Plain(text=f"啊嘞嘞？{event.member.name}的群名片从{event.origin}改为{event.current}了呢！")
-                ])
-            )
+            if event.member.name == event.origin:
+                pass
+            else:
+                await app.sendGroupMessage(
+                    group, MessageChain.create([
+                        Plain(text=f"啊嘞嘞？{event.member.name}的群名片从{event.origin}改为{event.current}了呢！")
+                    ])
+                )
     except AccountMuted:
         pass
 

--- a/SAGIRIBOT/Handler/Handlers/MiraiEventHandler.py
+++ b/SAGIRIBOT/Handler/Handlers/MiraiEventHandler.py
@@ -187,13 +187,20 @@ async def group_allow_member_invite_changed(app: GraiaMiraiApplication, event: G
 
 
 @bcc.receiver("MemberCardChangeEvent")
-async def member_card_changed(app: GraiaMiraiApplication, event: MemberCardChangeEvent, group: Group):
+async def member_card_changed(app: GraiaMiraiApplication, event: MemberCardChangeEvent):
     try:
-        await app.sendGroupMessage(
-            group, MessageChain.create([
-                Plain(text=f"啊嘞嘞？{event.member.name}的群名片被{event.operator.name}从{event.origin}改为{event.current}了呢！")
-            ])
-        )
+        if event.operator:
+            await app.sendGroupMessage(
+                group, MessageChain.create([
+                    Plain(text=f"啊嘞嘞？{event.member.name}的群名片被{event.operator.name}从{event.origin}改为{event.current}了呢！")
+                ])
+            )
+        else:
+            await app.sendGroupMessage(
+                group, MessageChain.create([
+                    Plain(text=f"啊嘞嘞？{event.member.name}的群名片从{event.origin}改为{event.current}了呢！")
+                ])
+            )
     except AccountMuted:
         pass
 


### PR DESCRIPTION
修复更改群名片时因无法获取 group 导致的 dispatcher 错误。
修复更改自己群名片时无法获取 operator 导致的错误。
----------
已测试
测试环境：Windows 11, Python 3.8, SQLite
mirai-* 版本: 2.7.1