### PR TITLE
Update super_resolution

### DIFF
--- a/sagiri_bot/handler/handlers/super_resolution/__init__.py
+++ b/sagiri_bot/handler/handlers/super_resolution/__init__.py
@@ -214,7 +214,7 @@ async def do_super_resolution(
         output, _ = await loop.run_in_executor(None, upsampler.enhance, image_array, 2)
     if is_gif:
         imageio.mimsave(
-            result, outputs[1:], format="gif", duration=image.info["duration"] / 1000
+            result, outputs, format=".gif", duration=image.info["duration"] / 1000
         )
     else:
         img = IMG.fromarray(output)


### PR DESCRIPTION
做了一丢参数上的修改，当Image为gif时，imageio.misave的format参数应为".gif"，否则会报如下错误：

![QQ图片20220925015700](https://user-images.githubusercontent.com/105123341/192112122-2aee7854-ea19-479d-be42-06dc98e1e51b.png)

同时存在 len(outputs)==1 的gif，故将imageio.misave的ims参数改为outputs。