### PR TITLE
Fix wrong image size and a typo

### DIFF
--- a/modules/self_contained/google_verification/utils.py
+++ b/modules/self_contained/google_verification/utils.py
@@ -8,12 +8,12 @@ FONT_SMALL = ImageFont.truetype(str(Path.cwd() / "resources" / "fonts" / "ArialE
 ZH_TOP = "请选择包含"
 ZH_BOTTOM = "的所有图块，如果没有，请点击“跳过”"
 EN_TOP = "Select all squares with"
-EN_BOTTOM = "If there are none, clik skip"
+EN_BOTTOM = "If there are none, click skip"
 
 
 def gen_verification(name: str, image: bytes, language: Literal["en", "zh"] = "zh") -> bytes:
     image = Image.open(BytesIO(image))
-    image = image.resize((900, 900))
+    image = image.resize((932, 932))
     canvas = Image.new("RGB", (1000, 1535), "#FFF")
     length = 233
     for i in range(4):


### PR DESCRIPTION
Typo: `clik` -> `click`
把图片大小从`(900, 900)`改成`(932, 932)`以修复生成出来的图有黑边的issue